### PR TITLE
Fix extension names and added query

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,11 @@ Azure Arc-enabled servers allow you to manage SQL Server instances running on-pr
   - Filters results to show only PAYG-licensed instances
   - Useful for identifying servers using consumption-based licensing
 
+- **query4-sql-extensions-non-payg-license.kql**
+  - Lists SQL Server extensions that are NOT configured with PAYG (Pay-As-You-Go) license type
+  - Filters results to show extensions with other license types (Paid, LicenseOnly) or no license type set
+  - Useful for identifying servers NOT using consumption-based licensing
+
 ### Documentation Files
 
 - **HOW-TO-RUN-QUERIES.md**

--- a/query1-arc-servers-with-sql-extensions.kql
+++ b/query1-arc-servers-with-sql-extensions.kql
@@ -7,5 +7,5 @@ resources
 | where properties.type =~ 'WindowsAgent.SqlServer' or properties.type =~ 'LinuxAgent.SqlServer'
 | extend machineName = tostring(split(id, '/')[8])
 | extend machineId = substring(id, 0, indexof(id, '/extensions/'))
-| project machineName, machineId, extensionName = name, extensionType = properties.type, provisioningState = properties.provisioningState, location, extensonVersion = properties.typeHandlerVersion, subscriptionId, resourceGroup
+| project machineName, machineId, extensionType = properties.type, provisioningState = properties.provisioningState, location, extensonVersion = properties.typeHandlerVersion, subscriptionId, resourceGroup
 | order by machineName asc

--- a/query1-arc-servers-with-sql-extensions.kql
+++ b/query1-arc-servers-with-sql-extensions.kql
@@ -4,8 +4,8 @@
 
 resources
 | where type =~ 'microsoft.hybridcompute/machines/extensions'
-| where properties.type =~ 'WindowsSqlServerExtension' or properties.type =~ 'LinuxSqlServerExtension'
+| where properties.type =~ 'WindowsAgent.SqlServer' or properties.type =~ 'LinuxAgent.SqlServer'
 | extend machineName = tostring(split(id, '/')[8])
 | extend machineId = substring(id, 0, indexof(id, '/extensions/'))
-| project machineName, machineId, extensionName = name, extensionType = properties.type, provisioningState = properties.provisioningState, location, subscriptionId, resourceGroup
+| project machineName, machineId, extensionName = name, extensionType = properties.type, provisioningState = properties.provisioningState, location, extensonVersion = properties.typeHandlerVersion, subscriptionId, resourceGroup
 | order by machineName asc

--- a/query2-sql-extensions-with-license-type.kql
+++ b/query2-sql-extensions-with-license-type.kql
@@ -4,7 +4,7 @@
 
 resources
 | where type =~ 'microsoft.hybridcompute/machines/extensions'
-| where properties.type =~ 'WindowsSqlServerExtension' or properties.type =~ 'LinuxSqlServerExtension'
+| where properties.type =~ 'WindowsAgent.SqlServer' or properties.type =~ 'LinuxAgent.SqlServer'
 | extend machineName = tostring(split(id, '/')[8])
 | extend licenseType = properties.settings.LicenseType
 | extend sqlVersion = properties.settings.SqlManagement.IsEnabled

--- a/query3-sql-extensions-payg-license.kql
+++ b/query3-sql-extensions-payg-license.kql
@@ -3,9 +3,9 @@
 
 resources
 | where type =~ 'microsoft.hybridcompute/machines/extensions'
-| where properties.type =~ 'WindowsSqlServerExtension' or properties.type =~ 'LinuxSqlServerExtension'
+| where properties.type =~ 'WindowsAgent.SqlServer' or properties.type =~ 'LinuxAgent.SqlServer'
 | extend machineName = tostring(split(id, '/')[8])
 | extend licenseType = properties.settings.LicenseType
 | where licenseType =~ 'PAYG'
-| project machineName, extensionName = name, extensionType = properties.type, licenseType, provisioningState = properties.provisioningState, location, subscriptionId, resourceGroup
+| project machineName, extensionType = properties.type, licenseType, provisioningState = properties.provisioningState, location, subscriptionId, resourceGroup
 | order by machineName asc

--- a/query4-sql-extensions-non-payg-license.kql
+++ b/query4-sql-extensions-non-payg-license.kql
@@ -1,0 +1,12 @@
+// Query to list all SQL Server extensions that are NOT set to "PAYG" (Pay-As-You-Go) license type
+// This query filters SQL Server extensions to show only those NOT configured with PAYG licensing
+// This includes extensions with other license types (Paid, LicenseOnly) or no license type set
+
+resources
+| where type =~ 'microsoft.hybridcompute/machines/extensions'
+| where properties.type =~ 'WindowsSqlServerExtension' or properties.type =~ 'LinuxSqlServerExtension'
+| extend machineName = tostring(split(id, '/')[8])
+| extend licenseType = properties.settings.LicenseType
+| where licenseType !~ 'PAYG'
+| project machineName, extensionName = name, extensionType = properties.type, licenseType, provisioningState = properties.provisioningState, location, subscriptionId, resourceGroup
+| order by machineName asc

--- a/query4-sql-extensions-non-payg-license.kql
+++ b/query4-sql-extensions-non-payg-license.kql
@@ -7,6 +7,6 @@ resources
 | where properties.type =~ 'WindowsSqlServerExtension' or properties.type =~ 'LinuxSqlServerExtension'
 | extend machineName = tostring(split(id, '/')[8])
 | extend licenseType = properties.settings.LicenseType
-| where licenseType !~ 'PAYG'
+| where licenseType !~ 'PAYG' or isempty(licenseType)
 | project machineName, extensionName = name, extensionType = properties.type, licenseType, provisioningState = properties.provisioningState, location, subscriptionId, resourceGroup
 | order by machineName asc

--- a/query4-sql-extensions-non-payg-license.kql
+++ b/query4-sql-extensions-non-payg-license.kql
@@ -4,7 +4,7 @@
 
 resources
 | where type =~ 'microsoft.hybridcompute/machines/extensions'
-| where properties.type =~ 'WindowsSqlServerExtension' or properties.type =~ 'LinuxSqlServerExtension'
+| where properties.type =~ 'WindowsAgent.SqlServer' or properties.type =~ 'LinuxAgent.SqlServer'
 | extend machineName = tostring(split(id, '/')[8])
 | extend licenseType = properties.settings.LicenseType
 | where licenseType !~ 'PAYG' or isempty(licenseType)


### PR DESCRIPTION
This pull request updates several KQL queries and documentation to improve how SQL Server extensions are identified and filtered by license type in Azure Arc-enabled servers. The main focus is on refining the queries to use the correct extension type names and adding a new query to help identify servers not using Pay-As-You-Go (PAYG) licensing.

**Query improvements:**

* Updated all queries to use the correct extension type names: `WindowsAgent.SqlServer` and `LinuxAgent.SqlServer` instead of the previous `WindowsSqlServerExtension` and `LinuxSqlServerExtension`. This ensures the queries target the right resources in Azure Arc. [[1]](diffhunk://#diff-0d540a4f7d470d9d5784bc9fec16be9db9654807b90b35e4431a44462fd97635L7-R10) [[2]](diffhunk://#diff-12cfefc74e7646e98c7386acfc2fe1aa0e8e4f60055631bd21e5e3b5510a298cL7-R7) [[3]](diffhunk://#diff-cbe996ae95ed022b195e28700a00e1b24f8df727a7de1876a652fe8f95bc2a3aL6-R10)

* Added a new query, `query4-sql-extensions-non-payg-license.kql`, which lists SQL Server extensions that are NOT configured with PAYG licensing. This helps identify servers using other license types or no license type at all.

**Documentation updates:**

* Updated the `README.md` to document the new query and clarify its purpose for identifying non-PAYG licensed servers.

* Minor improvements to projected fields in existing queries, such as including the extension version in query results for better visibility.

These changes make it easier to audit and manage SQL Server licensing across your Azure Arc-enabled servers.